### PR TITLE
fix: 修复获取窗口id失败

### DIFF
--- a/src/button_center.py
+++ b/src/button_center.py
@@ -54,7 +54,7 @@ class ButtonCenter:
                     interrupt=False,
                     out_debug_flag=False,
                     command_log=False,
-                ).split("\n")
+                ).strip().split("\n")
                 app_id_list = [int(_id) for _id in app_id if _id]
                 app_id_list.sort()
                 logger.debug(f"app_id_list: {app_id_list}")
@@ -557,7 +557,7 @@ class ButtonCenter:
         cmd = f"xdotool search --classname {name}"
         app_id = CmdCtl.run_cmd(
             cmd, interrupt=False, out_debug_flag=False, command_log=False
-        )
+        ).strip()
         return len([i for i in app_id.split("\n") if i])
 
     @classmethod
@@ -570,7 +570,7 @@ class ButtonCenter:
         cmd = f"xdotool search --onlyvisible --classname {name}"
         app_id = CmdCtl.run_cmd(
             cmd, interrupt=False, out_debug_flag=False, command_log=False
-        )
+        ).strip()
         if app_id:
             return [i for i in app_id.split("\n") if i]
         raise ApplicationStartError(app_id)
@@ -600,7 +600,7 @@ class ButtonCenter:
                 interrupt=False,
                 out_debug_flag=False,
                 command_log=False,
-            ).split("\n")
+            ).strip().split("\n")
             app_id_list = [int(_id) for _id in app_id if _id]  # to int
             app_id_list.sort()
             return app_id_list[-1]


### PR DESCRIPTION
fix: 当使用xdotool获取窗口ID时，终端输出最后包含一个回车，如果查询到多个窗口，代码中直接使用按回车split，会导致生成的列表最后存在一个空字符串，这在将窗口ID转化为int类型时会导致错误。

Log: 修复获取窗口id失败