### PR TITLE
fix: fix the issue of failing to retrieve window ID

### DIFF
--- a/src/button_center.py
+++ b/src/button_center.py
@@ -557,7 +557,7 @@ class ButtonCenter:
         cmd = f"xdotool search --classname {name}"
         app_id = CmdCtl.run_cmd(
             cmd, interrupt=False, out_debug_flag=False, command_log=False
-        )
+        ).strip()
         return len([i for i in app_id.split("\n") if i])
 
     @classmethod


### PR DESCRIPTION
Description: When using xdotool to retrieve window IDs, if there are multiple windows, the output ends with '\n'. In the original code, directly splitting the string using split("\n") can result in the last element of the resulting list being an empty string. This situation leads to errors when iterating through the window IDs and converting them to int type

Log: fix the issue of failing to retrieve window ID