### PR TITLE
fix: get python version number by command, not constant 3.7

### DIFF
--- a/_env_base.sh
+++ b/_env_base.sh
@@ -13,6 +13,9 @@ whitelist="/usr/share/deepin-elf-verify/whitelist"
 pypi_mirror="https://pypi.tuna.tsinghua.edu.cn/simple"
 echo "${PASSWORD}" | sudo -S su  > /dev/null 2>&1
 
+PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+echo "${PYTHON_VERSION}"
+
 check_status(){
     if [ $? = 0 ]; then
         echo -e "$1\t安装成功 √"
@@ -87,8 +90,7 @@ system_env(){
          echo 'export QT_LINUX_ACCESSIBILITY_ALWAYS_ON=1' >> $HOME/.bashrc
     fi
     source $HOME/.bashrc
-
-    sudo rm -rf /usr/local/lib/python3.7/dist-packages/*.pth
+    sudo rm -rf /usr/local/lib/python$PYTHON_VERSION/dist-packages/*.pth
     echo "cd ${ROOT_DIR}/src/depends/sniff/;python3 sniff" | sudo tee /usr/bin/sniff > /dev/null 2>&1
     sudo chmod +x /usr/bin/sniff
 
@@ -112,6 +114,6 @@ install_py_deb(){
         exit 520
     fi
     dpkg -x ${1}*.deb ${1}
-    cp -r ./${1}/usr/lib/python3/dist-packages/* ${2}/lib/python3.7/site-packages/
+    cp -r ./${1}/usr/lib/python3/dist-packages/* ${2}/lib/python$PYTHON_VERSION/site-packages/
     rm -rf ${1}*
 }

--- a/env.sh
+++ b/env.sh
@@ -96,7 +96,7 @@ done
 
 apt download python3-gi-cairo > /tmp/env.log 2>&1
 dpkg -x python3-gi-cairo*.deb python3-gi-cairo
-cp -r ./python3-gi-cairo/usr/lib/python3/dist-packages/gi/* ${python_virtualenv_path}/lib/python3.7/site-packages/gi/
+cp -r ./python3-gi-cairo/usr/lib/python3/dist-packages/gi/* ${python_virtualenv_path}/lib/python$PYTHON_VERSION/site-packages/gi/
 rm -rf python3-gi-cairo*
 
 cd ${ROOT_DIR}/src/utils/


### PR DESCRIPTION
The python version number should be dynamic fetched, should not be a constant value of 3.7.