### PR TITLE
assert_ocr_exist新增识别任一目标字符功能

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,7 @@ import sys
 from os import environ
 
 environ["DISPLAY"] = ":0"
+environ["XAUTHORITY"] = "/home/uos/.Xauthority"
 from setting.globalconfig import SystemPath
 
 for i in SystemPath:

--- a/manage.py
+++ b/manage.py
@@ -13,6 +13,7 @@ from argparse import ArgumentParser
 
 os.environ["DISPLAY"] = ":0"
 os.environ["PIPENV_VERBOSITY"] = "-1"
+os.environ["XAUTHORITY"] = "/home/uos/.Xauthority"
 
 from setting.globalconfig import SystemPath
 


### PR DESCRIPTION
解决issues：OCR断言希望新增any识别模式，当给多个识别对象时，识别到任意一一个对象存在就算通过 #50