### PR TITLE
fix: 修复清华源安装pipenv被屏蔽访问的问题

### DIFF
--- a/src/utils/env_vir.sh
+++ b/src/utils/env_vir.sh
@@ -64,7 +64,7 @@ env
 
 init_pip
 
-sudo pip3 install pipenv > /tmp/env.log 2>&1
+sudo pip3 install pipenv -i https://repo.huaweicloud.com/repository/pypi/simple > /tmp/env.log 2>&1
 if [ $? = 0 ]; then
     echo -e "pipenv\t安装成功 √"
 else


### PR DESCRIPTION
使用清华源安装 pipenv 包时，被拒绝访问，导致安装失败